### PR TITLE
redis-py versions based on python version

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,15 +2,15 @@ name: CI
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.rst'
-      - '**/*.md'
     branches:
       - master
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.rst'
+      - '**/*.md'
 
 jobs:
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -20,7 +20,7 @@ jobs:
      strategy:
        max-parallel: 15
        matrix:
-         python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
+         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
      env:
        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
      name: Python ${{ matrix.python-version }} test

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -39,17 +39,17 @@ jobs:
          id: cache
          with:
            path: ~/.virtualenvs
-           key: poetry-${{ hashFiles('**/poetry.lock') }}
+           key: poetry-${{ hashFiles('**/poetry.lock') }}-${{matrix.python-version}}
            restore-keys: |
-             poetry-${{ hashFiles('**/poetry.lock') }}
+             poetry-${{ hashFiles('**/poetry.lock') }}-${{matrix.python-version}}
 
        - name: install redis
          run: |
-           sudo apt-get update
-           sudo apt-get install -y redis
+           sudo apt-get update -q
+           sudo apt-get install -qy redis
        - name: run tests
          run: |
-           pip install -r dev_requirements.txt
+           pip install -q -r dev_requirements.txt
            tox -e python${{ matrix.python-version }}
        - name: build and install the package in this python version
          run: |

--- a/RAMP/commands_discovery.py
+++ b/RAMP/commands_discovery.py
@@ -35,7 +35,7 @@ def _get_modules_list(redis_client):
     """
     Finds out which modules are loaded into Redis.
     """
-    modules_list = redis_client.execute_command("MODULE LIST")
+    modules_list = redis_client.module_list()
     # MODULE LIST response contains an array of module name and version.
     #    1) 1) "name"
     #       2) "graph"
@@ -43,10 +43,7 @@ def _get_modules_list(redis_client):
     #       4) (integer) 1
 
     loaded_modules = []
-    for module in modules_list:
-        module_name = module[1]
-        module_version = float(module[3])
-        loaded_modules.append((module_name, module_version))
+    loaded_modules = [(m['name'], float(m['ver'])) for m in modules_list]
 
     return loaded_modules
 
@@ -73,7 +70,7 @@ def _get_redis_commands(redis_client):
     """
     Retrieves a set of commands from Redis
     """
-    commands = redis_client.execute_command("COMMAND")
+    commands = redis_client.command()
     redis_commands = set()
     for command in commands:
         redis_commands.add(command[0])
@@ -92,7 +89,7 @@ def _get_redis_command_info(redis_client, command_name):
     #    5) (integer) 1
     #    6) (integer) 1
 
-    if len(command_info) is not 1:
+    if len(command_info) != 1:
         return None
 
     command_info = command_info[0]

--- a/RAMP/commands_discovery.py
+++ b/RAMP/commands_discovery.py
@@ -71,10 +71,7 @@ def _get_redis_commands(redis_client):
     Retrieves a set of commands from Redis
     """
     commands = redis_client.command()
-    redis_commands = set()
-    for command in commands:
-        redis_commands.add(command[0])
-    return redis_commands
+    return commands
 
 def _get_redis_command_info(redis_client, command_name):
     """
@@ -116,7 +113,8 @@ def discover_modules_commands(path_to_module, module_args):
             raise Exception("Failed to load module {} {}".format(path_to_module, module_args))
 
         extended_redis_commands = _get_redis_commands(redis_client)
-        module_commands = extended_redis_commands - core_redis_commands
+        module_commands = (set(extended_redis_commands.keys()).symmetric_difference(set(core_redis_commands.keys())))
+        # module_commands = extended_redis_commands - core_redis_commands
 
         for module_command in module_commands:
             command = _get_redis_command_info(redis_client, module_command)

--- a/RAMP/packer.py
+++ b/RAMP/packer.py
@@ -39,7 +39,7 @@ def init_from_manifest(metadata, manifest):
     Creates module metadata from user provided menifest file
     """
     try:
-        data = yaml.load(manifest)
+        data = yaml.load(manifest, Loader=yaml.FullLoader)
         for key, val in data.items():
             if key in metadata:
                 metadata[key] = val

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ramp-packer"
-version = "2.2.1"
+version = "2.3.0"
 description = "Packs for Redis modules into a distributable format"
 authors = ["Redis OSS <oss@redis.com>"]
 license = "BSD-2-Clause"
@@ -14,7 +14,6 @@ classifiers = [
     'Topic :: Database',
     'Programming Language :: Python',
     'Intended Audience :: Developers',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
@@ -30,15 +29,12 @@ ramp = "RAMP.ramp:ramp"
 
 
 [tool.poetry.dependencies]
-python = "^2.7,<2.8 || >= 3.6,<4"
+python = ">= 3.6,<4"
 PyYAML = "5.3.1"
-click = [ {version = "^7", python = "~2.7"}, {version = "^8", python = ">=3.6"} ]
+click = "^8"
 semantic-version = "^2.8.5"
 typing = "^3.0.0"
-redis = [
-    {version = "^4.1.0", python  = "^3.6"},
-    {version = "^3.5.3", python  = "^2.7,<2.8"},
-]
+redis = "^4.1.0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^5.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,11 @@ ramp = "RAMP.ramp:ramp"
 
 [tool.poetry.dependencies]
 python = ">= 3.6,<4"
-PyYAML = "5.3.1"
 click = "^8"
 semantic-version = "^2.8.5"
 typing = "^3.0.0"
 redis = "^4.1.0"
+PyYAML = "^6.0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^5.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,14 @@ ramp = "RAMP.ramp:ramp"
 
 [tool.poetry.dependencies]
 python = "^2.7,<2.8 || >= 3.6,<4"
-redis = "^3.5.3"
 PyYAML = "5.3.1"
 click = [ {version = "^7", python = "~2.7"}, {version = "^8", python = ">=3.6"} ]
 semantic-version = "^2.8.5"
 typing = "^3.0.0"
+redis = [
+    {version = "^4.1.0", python  = "^3.6"},
+    {version = "^3.5.3", python  = "^2.7,<2.8"},
+]
 
 [tool.poetry.dev-dependencies]
 coverage = "^5.4"

--- a/test.py
+++ b/test.py
@@ -156,7 +156,7 @@ def test_bundle_from_cmd():
     commands = metadata["commands"]
     validate_module_commands(commands)
 
-def _test_bundle_from_menifest(manifest_file, manifest_file_path):
+def _test_bundle_from_manifest(manifest_file, manifest_file_path):
     """
     Test metadata generated from menifest file is as expected.
     """
@@ -191,14 +191,14 @@ def _test_bundle_from_menifest(manifest_file, manifest_file_path):
     commands = metadata["commands"]
     validate_module_commands(commands)
 
-def test_bundle_from_menifest():
-    _test_bundle_from_menifest(MENIFEST_FILE, MENIFEST_FILE_PATH)
+def test_bundle_from_manifest():
+    _test_bundle_from_manifest(MENIFEST_FILE, MENIFEST_FILE_PATH)
 
 def test_bundle_from_menifest2():
     _test_bundle_from_menifest(MENIFEST2_FILE, MENIFEST2_FILE_PATH)
 
 if __name__ == '__main__':
     test_defaults()
-    test_bundle_from_menifest()
+    test_bundle_from_manifest()
     test_bundle_from_cmd()
     print("PASS")

--- a/test.py
+++ b/test.py
@@ -181,7 +181,7 @@ def _test_bundle_from_menifest(manifest_file, manifest_file_path):
         assert metadata["git_sha"] == git_sha
 
     with open(MENIFEST_FILE_PATH, 'r') as f:
-        manifest = yaml.load(f)
+        manifest = yaml.load(f, Loader=yaml.FullLoader)
         for key in manifest:
             if key == 'dependencies' or key == 'optional-dependencies':
                 assert metadata[key] == unpacker.normalize_dependencies(manifest[key])

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ graph_version = 1.0.12
 allowlist_externals =
     wget
     rm
+    unzip
 commands_pre:
     pip install -r dev_requirements.txt
     rm -rf test_module redisgraph.zip

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.2.0
 isolated_build = True
-envlist = {python2.7,python3.6,python3.7,python3.8,python3.9,python3.10}
+envlist = {python3.6,python3.7,python3.8,python3.9,python3.10}
 
 [main]
 graph_version = 1.0.12


### PR DESCRIPTION
Supporting redis-py 4.1+, python 3.6+ only now. This includes the version bump so that we can release 0.5.0.