### PR TITLE
Add an option for redis-server args

### DIFF
--- a/RAMP/commands_discovery.py
+++ b/RAMP/commands_discovery.py
@@ -27,8 +27,8 @@ class ModuleCommand(object):
     def to_dict(self):
         return self.__dict__
 
-def redis():
-    redis_client = DisposableRedis(verbose=config.debug)
+def redis(extra_args=None):
+    redis_client = DisposableRedis(verbose=config.debug, **extra_args)
     return redis_client
 
 def _get_modules_list(redis_client):
@@ -100,13 +100,15 @@ def _get_redis_command_info(redis_client, command_name):
 
     return ModuleCommand(command_name, command_arity, flags, first_key, last_key, step)
 
-def discover_modules_commands(path_to_module, module_args):
+def discover_modules_commands(path_to_module, module_args, redis_extra_args=None):
     """
         Retrieves module command(s) info.
         :param path_to_module: where does the module file is located
+        :param module_args: command line arguments for the module
+        :param redis_extra_args: command line arguments for redis
         Returns Module object populated with command(s) info.
     """
-    with redis() as redis_client:
+    with redis(redis_extra_args) as redis_client:
         core_redis_commands = _get_redis_commands(redis_client)
         module = _load_module(redis_client, path_to_module, module_args)
         if module is None:

--- a/RAMP/disposableredis/__init__.py
+++ b/RAMP/disposableredis/__init__.py
@@ -63,8 +63,8 @@ class DisposableRedis(object):
             #cwd=os.getcwd(),
             stdin=subprocess.PIPE,
             stdout=out,
-            stderr=err
-#             env=os.environ.copy()
+            stderr=err,
+            env=os.environ.copy(),
         )
 
         while True:

--- a/RAMP/module_metadata.py
+++ b/RAMP/module_metadata.py
@@ -31,6 +31,7 @@ CONFIG_COMMAND = ""
 OVERIDE_COMMAND = []  # type: List[Dict[str, str]]
 ADD_COMMAND = []  # type: List[Dict[str, str]]
 CRDB_ARGS = {}  # type: List[Dict[str, str]]
+REDIS_ARGS = {}  # type: List[Dict[str, str]]
 
 FIELDS = [
     "architecture",
@@ -60,7 +61,8 @@ FIELDS = [
     "semantic_version",
     "sha256",
     "version",
-    "crdb"
+    "crdb",
+    "redis_args"
 ]  # type: List[str]
 
 
@@ -105,4 +107,5 @@ def create_default_metadata(module_path):
         "overide_command": OVERIDE_COMMAND,
         "add_command": ADD_COMMAND,
         "crdb": CRDB_ARGS,
+        "redis_args": REDIS_ARGS,
     }

--- a/RAMP/packer.py
+++ b/RAMP/packer.py
@@ -70,7 +70,7 @@ def archive(module_path, metadata, archive_name='module.zip'):
 def package(module, **args):
     module_path = module
 
-    nonkeys = dict.fromkeys(['manifest', 'verbose', 'print_filename_only', 'packname_file', 'output'], 1)
+    nonkeys = dict.fromkeys(['manifest', 'verbose', 'print_filename_only', 'packname_file', 'output', 'redis_args'], 1)
     manifest = args['manifest']
     print_filename_only = args['print_filename_only']
     packname_file = args['packname_file']
@@ -94,7 +94,8 @@ def package(module, **args):
 
     # Load module into redis and discover its commands
     cmd_line_args = metadata.pop('run_command_line_args', None)
-    module = discover_modules_commands(module_path, cmd_line_args if cmd_line_args else metadata["command_line_args"])
+    redis_args = metadata.pop('redis_args')
+    module = discover_modules_commands(module_path, cmd_line_args if cmd_line_args else metadata["command_line_args"], redis_args)
     metadata["module_name"] = module.name
     metadata["version"] = module.version
     metadata["semantic_version"] = str(version_to_semantic_version(module.version))

--- a/RAMP/ramp.py
+++ b/RAMP/ramp.py
@@ -32,6 +32,13 @@ def jsons_str_tuple_to_jsons_tuple(ctx, param, value):
         return [json.loads(a) for a in value]
 
 
+def json_str_to_json(ctx, param, value):
+    """
+    Converts json str into python map
+    """
+    return json.loads(value) if value else None
+
+
 @click.group()
 @click.version_option(version=VERSION)
 def ramp():
@@ -103,6 +110,7 @@ def unpack(bundle):
 @click.option('--packname-file', default=None, help="Write package name to the file")
 @click.option('--verbose', '-v', is_flag=True, default=False, help='verbose mode: print the resulting metadata')
 @click.option('--debug', is_flag=True, default=False, help='Print interaction with Redis. Implies --verbose.')
+@click.option('--redis-args', 'redis_args', callback=json_str_to_json, help='redis command line arguments')
 def pack(module, *args, **kwargs):
     config.set(kwargs)
     return package(module, **kwargs)

--- a/example.manifest.yml
+++ b/example.manifest.yml
@@ -25,4 +25,6 @@ crdb:
     supported_featureset_versions:
         - 1
         - 3
+redis_args:
+    loglevel: debug
 

--- a/example2.manifest.yml
+++ b/example2.manifest.yml
@@ -37,3 +37,5 @@ crdb:
     supported_featureset_versions:
         - 1
         - 3
+redis_args:
+    loglevel: debug

--- a/test.py
+++ b/test.py
@@ -92,6 +92,7 @@ def test_defaults():
     assert metadata["capabilities"] == module_metadata.MODULE_CAPABILITIES
     assert metadata["ramp_format_version"] == module_metadata.RAMP_FORMAT_VERSION
     assert metadata["sha256"] == sha256_checksum(MODULE_FILE_PATH)
+    assert 'redis_args' not in metadata
 
     git_sha = get_git_sha()
     if git_sha is not None:
@@ -123,7 +124,8 @@ def test_bundle_from_cmd():
             '-o', BUNDLE_ZIP_FILE, '-cc', CONFIG_COMMAND, '-E', 'graph.bulk',
             '-E', 'graph.BULK',
             '--overide-command', '{"command_name": "graph.EXPLAIN"}',
-            '--add-command', '{"command_name": "test"}']
+            '--add-command', '{"command_name": "test"}',
+            '--redis-args', '{"loglevel": "debug"}']
 
     runner = CliRunner()
     result = runner.invoke(ramp.pack, argv)
@@ -148,6 +150,7 @@ def test_bundle_from_cmd():
     assert metadata["config_command"] == CONFIG_COMMAND
     assert metadata["sha256"] == sha256_checksum(MODULE_FILE_PATH)
     assert len(metadata["capabilities"]) == len(MODULE_CAPABILITIES)
+    assert 'redis_args' not in metadata
 
     git_sha = get_git_sha()
     if git_sha is not None:
@@ -185,6 +188,8 @@ def _test_bundle_from_manifest(manifest_file, manifest_file_path):
         for key in manifest:
             if key == 'dependencies' or key == 'optional-dependencies':
                 assert metadata[key] == unpacker.normalize_dependencies(manifest[key])
+            elif key == 'redis_args':
+                assert 'redis_args' not in metadata
             else:
                 assert metadata[key] == manifest[key]
 


### PR DESCRIPTION
This is available with `--redis-args`.
For example:
`ramp pack --redis-args "{\"key\": \"value\"}" ...`