### PR TITLE
Add rocky9 support

### DIFF
--- a/RAMP/module_metadata.py
+++ b/RAMP/module_metadata.py
@@ -87,6 +87,7 @@ RLEC_OS_MAP = {
     "rocky8": "rhel8",
     "almalinux8": "rhel8",
     "oracle8": "rhel8",
+    "rocky9": "rhel9"
 }
 
 def get_curr_os():


### PR DESCRIPTION
Add rocky9 -> rhel9 OS to the `RLEC_OS_MAP` which converts the OS on which we build the module to the RLEC os distribution (to appear in the module.json file)  