### PR TITLE
Update bigstore version 2 support flag to be a boolean option in comm…

### DIFF
--- a/RAMP/ramp.py
+++ b/RAMP/ramp.py
@@ -99,7 +99,7 @@ def unpack(bundle):
 @click.option('--redis-min-version', '-r', 'min_redis_version', default=None, help='redis minimum version')
 @click.option('--redis-pack-min-version', '-R', 'min_redis_pack_version', default=None, help='redis pack minimum version')
 @click.option('--redis-compatible-version', '-cr', 'compatible_redis_version', default=None, help='redis compatible version')
-@click.option('--bigstore-version-2-support', 'bigstore_version_2_support', default=False, help='This module supports RofV2')
+@click.option('--bigstore-version-2-support', 'bigstore_version_2_support', is_flag=True, default=None, help='This module supports RofV2')
 @click.option('--config-command', '-cc', default=None, help='command used to configure module args at runtime')
 @click.option('--os', '-O', default=None, help='build target OS (Darwin/Linux)')
 @click.option('--capabilities', '-C', callback=comma_seperated_to_list, help='comma separated list of module capabilities')

--- a/test.py
+++ b/test.py
@@ -124,7 +124,7 @@ def test_bundle_from_cmd():
             '-d', display_name, '-b', capability_name, '-n', module_name,
             '-h', homepage, '-l', _license, '-c', command_line_args,
             '-r', min_redis_version, '-R', min_redis_pack_version, '-cr', compatible_redis_version,
-            '--bigstore-version-2-support', bigstore_version_2_support,
+            '--bigstore-version-2-support',
             '-C', ','.join([cap['name'] for cap in MODULE_CAPABILITIES]),
             '-o', BUNDLE_ZIP_FILE, '-cc', CONFIG_COMMAND, '-E', 'graph.bulk',
             '-E', 'graph.BULK',


### PR DESCRIPTION
…and line and None as default

the reason is that ramp overrides the boolean default value, we need to think about how to refactor it. 