### PR TITLE
MOD-15930 Use devcontainer distro for OS metadata

### DIFF
--- a/RAMP/module_metadata.py
+++ b/RAMP/module_metadata.py
@@ -99,8 +99,26 @@ RLEC_OS_MAP = {
     "oracle9": "rhel9",
 }
 
+DEVCONTAINER_PATH = "/etc/devcontainer"
+
+
+def _read_key_value_file(path):
+    values = {}
+    with open(path) as f:
+        for line in f:
+            if "=" in line:
+                key, value = line.strip().split("=", 1)
+                values[key] = value.strip("\"'")
+    return values
+
+
 def get_curr_os():
     global RLEC_OS_MAP
+    if os.path.exists(DEVCONTAINER_PATH):
+        devcontainer_os = _read_key_value_file(DEVCONTAINER_PATH).get("DISTRO")
+        if devcontainer_os:
+            return devcontainer_os
+
     curr_os = '%s%s' % (distro.id(), distro.version_parts()[0])
     rlec_os = RLEC_OS_MAP.get(curr_os, curr_os)
     return rlec_os

--- a/test_module_metadata.py
+++ b/test_module_metadata.py
@@ -1,0 +1,41 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from RAMP import module_metadata
+
+
+class GetCurrOsTest(unittest.TestCase):
+    def test_uses_devcontainer_distro_before_host_distro(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            devcontainer_path = os.path.join(temp_dir, "devcontainer")
+            with open(devcontainer_path, "w") as f:
+                f.write("DISTRO=amzn2023\n")
+
+            with mock.patch.object(module_metadata, "DEVCONTAINER_PATH", devcontainer_path):
+                with mock.patch.object(module_metadata.distro, "id", return_value="rocky"):
+                    with mock.patch.object(module_metadata.distro, "version_parts", return_value=("8",)):
+                        self.assertEqual(module_metadata.get_curr_os(), "amzn2023")
+
+    def test_falls_back_to_distro_when_devcontainer_has_no_distro(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            devcontainer_path = os.path.join(temp_dir, "devcontainer")
+            with open(devcontainer_path, "w") as f:
+                f.write("OTHER=value\n")
+
+            with mock.patch.object(module_metadata, "DEVCONTAINER_PATH", devcontainer_path):
+                with mock.patch.object(module_metadata.distro, "id", return_value="rocky"):
+                    with mock.patch.object(module_metadata.distro, "version_parts", return_value=("8",)):
+                        self.assertEqual(module_metadata.get_curr_os(), "rhel8")
+
+    def test_preserves_distro_fallback_when_devcontainer_is_absent(self):
+        devcontainer_path = os.path.join(tempfile.gettempdir(), "missing-devcontainer")
+        with mock.patch.object(module_metadata, "DEVCONTAINER_PATH", devcontainer_path):
+            with mock.patch.object(module_metadata.distro, "id", return_value="ubuntu"):
+                with mock.patch.object(module_metadata.distro, "version_parts", return_value=("22",)):
+                    self.assertEqual(module_metadata.get_curr_os(), "ubuntu22")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands_pre:
     pip install -r dev_requirements.txt
     rm -rf test_module redisgraph.zip
 commands:
+    python -m unittest test_module_metadata.py
     wget -q https://s3.amazonaws.com/redismodules/redisgraph/redisgraph.Linux-x86_64.{[main]graph_version}.zip -O redisgraph.zip
     unzip redisgraph.zip -d test_module
     coverage run test.py


### PR DESCRIPTION
## Summary

Use `/etc/devcontainer` as the preferred source for the generated `operating_systems` metadata when a devcontainer image provides a `DISTRO` value.

## Changes

- Add `/etc/devcontainer` parsing in `RAMP/module_metadata.py`
- Prefer `DISTRO` from `/etc/devcontainer` before falling back to the existing `distro` package detection
- Add focused unit tests for devcontainer precedence and fallback behavior
- Run the new unit test from `tox.ini`

## Context

Redis module build images can expose the intended package platform in `/etc/devcontainer` while `/etc/os-release` may represent a lower-level compatibility base. RAMP should use the devcontainer platform metadata when available so generated `module.json` matches the platform used by the packaging environment.

Validation:

- `python3 -m unittest test_module_metadata.py`
- `python3 -m py_compile RAMP/module_metadata.py test_module_metadata.py`
- `git diff --check`