### PR TITLE
Fail fast on missing DISTRO and map focal/jammy to ubuntu20/ubuntu22

### DIFF
--- a/RAMP/module_metadata.py
+++ b/RAMP/module_metadata.py
@@ -112,13 +112,18 @@ def _read_key_value_file(path):
     return values
 
 
+DEVCONTAINER_OS_MAP = {
+    "focal": "ubuntu20",
+    "jammy": "ubuntu22",
+    "noble": "ubuntu24",
+}
+
+
 def get_curr_os():
     global RLEC_OS_MAP
     if os.path.exists(DEVCONTAINER_PATH):
         devcontainer_os = _read_key_value_file(DEVCONTAINER_PATH)["DISTRO"]
-        return (devcontainer_os
-                .replace("focal", "ubuntu20")
-                .replace("jammy", "ubuntu22"))
+        return DEVCONTAINER_OS_MAP.get(devcontainer_os, devcontainer_os)
     curr_os = '%s%s' % (distro.id(), distro.version_parts()[0])
     rlec_os = RLEC_OS_MAP.get(curr_os, curr_os)
     return rlec_os

--- a/RAMP/module_metadata.py
+++ b/RAMP/module_metadata.py
@@ -115,10 +115,10 @@ def _read_key_value_file(path):
 def get_curr_os():
     global RLEC_OS_MAP
     if os.path.exists(DEVCONTAINER_PATH):
-        devcontainer_os = _read_key_value_file(DEVCONTAINER_PATH).get("DISTRO")
-        if devcontainer_os:
-            return devcontainer_os
-
+        devcontainer_os = _read_key_value_file(DEVCONTAINER_PATH)["DISTRO"]
+        return (devcontainer_os
+                .replace("focal", "ubuntu20")
+                .replace("jammy", "ubuntu22"))
     curr_os = '%s%s' % (distro.id(), distro.version_parts()[0])
     rlec_os = RLEC_OS_MAP.get(curr_os, curr_os)
     return rlec_os

--- a/test_module_metadata.py
+++ b/test_module_metadata.py
@@ -18,16 +18,35 @@ class GetCurrOsTest(unittest.TestCase):
                     with mock.patch.object(module_metadata.distro, "version_parts", return_value=("8",)):
                         self.assertEqual(module_metadata.get_curr_os(), "amzn2023")
 
-    def test_falls_back_to_distro_when_devcontainer_has_no_distro(self):
+    def test_raises_when_devcontainer_has_no_distro(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             devcontainer_path = os.path.join(temp_dir, "devcontainer")
             with open(devcontainer_path, "w") as f:
                 f.write("OTHER=value\n")
 
             with mock.patch.object(module_metadata, "DEVCONTAINER_PATH", devcontainer_path):
-                with mock.patch.object(module_metadata.distro, "id", return_value="rocky"):
-                    with mock.patch.object(module_metadata.distro, "version_parts", return_value=("8",)):
-                        self.assertEqual(module_metadata.get_curr_os(), "rhel8")
+                with self.assertRaises(KeyError):
+                    module_metadata.get_curr_os()
+
+    def test_maps_ubuntu_codenames_to_versions(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for distro_value, expected in (("focal", "ubuntu20"), ("jammy", "ubuntu22")):
+                devcontainer_path = os.path.join(temp_dir, "devcontainer")
+                with open(devcontainer_path, "w") as f:
+                    f.write("DISTRO=%s\n" % distro_value)
+
+                with mock.patch.object(module_metadata, "DEVCONTAINER_PATH", devcontainer_path):
+                    self.assertEqual(module_metadata.get_curr_os(), expected)
+
+    def test_amzn2023_unchanged_but_jammy_mapped_to_ubuntu22(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for distro_value, expected in (("amzn2023", "amzn2023"), ("jammy", "ubuntu22")):
+                devcontainer_path = os.path.join(temp_dir, "devcontainer")
+                with open(devcontainer_path, "w") as f:
+                    f.write("DISTRO=%s\n" % distro_value)
+
+                with mock.patch.object(module_metadata, "DEVCONTAINER_PATH", devcontainer_path):
+                    self.assertEqual(module_metadata.get_curr_os(), expected)
 
     def test_preserves_distro_fallback_when_devcontainer_is_absent(self):
         devcontainer_path = os.path.join(tempfile.gettempdir(), "missing-devcontainer")

--- a/test_module_metadata.py
+++ b/test_module_metadata.py
@@ -30,7 +30,7 @@ class GetCurrOsTest(unittest.TestCase):
 
     def test_maps_ubuntu_codenames_to_versions(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            for distro_value, expected in (("focal", "ubuntu20"), ("jammy", "ubuntu22")):
+            for distro_value, expected in (("focal", "ubuntu20"), ("jammy", "ubuntu22"), ("noble", "ubuntu24")):
                 devcontainer_path = os.path.join(temp_dir, "devcontainer")
                 with open(devcontainer_path, "w") as f:
                     f.write("DISTRO=%s\n" % distro_value)


### PR DESCRIPTION
Fail fast when DISTRO is missing from the devcontainer file, and map focal/jammy to ubuntu20/ubuntu22.